### PR TITLE
Enable downstream CI

### DIFF
--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -1,0 +1,7 @@
+dependencies: |
+  ecmwf/ecbuild
+  ecmwf/eckit
+  ecmwf/atlas
+  ecmwf/fckit
+dependency_branch: develop
+parallelism_factor: 8

--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -3,5 +3,7 @@ dependencies: |
   ecmwf/eckit
   ecmwf/atlas
   ecmwf/fckit
+dependency_cmake_options: |
+  ecmwf/atlas: "-DENABLE_FORTRAN=ON"
 dependency_branch: develop
 parallelism_factor: 8

--- a/.github/ci-config.yml
+++ b/.github/ci-config.yml
@@ -1,8 +1,8 @@
 dependencies: |
   ecmwf/ecbuild
   ecmwf/eckit
-  ecmwf/atlas
   ecmwf/fckit
+  ecmwf/atlas
 dependency_cmake_options: |
   ecmwf/atlas: "-DENABLE_FORTRAN=ON"
 dependency_branch: develop

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -1,0 +1,9 @@
+build:
+  modules:
+    - ninja
+  dependencies:
+    - ecmwf/ecbuild@develop
+    - ecmwf/eckit@develop
+    - ecmwf/atlas@develop
+    - ecmwf/fckit@develop
+  parallel: 64

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -4,8 +4,8 @@ build:
   dependencies:
     - ecmwf/ecbuild@develop
     - ecmwf/eckit@develop
-    - ecmwf/atlas@develop
     - ecmwf/fckit@develop
+    - ecmwf/atlas@develop
   dependency_cmake_options:
     - ecmwf/atlas:-DENABLE_FORTRAN=ON
   parallel: 64

--- a/.github/ci-hpc-config.yml
+++ b/.github/ci-hpc-config.yml
@@ -6,4 +6,6 @@ build:
     - ecmwf/eckit@develop
     - ecmwf/atlas@develop
     - ecmwf/fckit@develop
+  dependency_cmake_options:
+    - ecmwf/atlas:-DENABLE_FORTRAN=ON
   parallel: 64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: ci
+
+on:
+  # Trigger the workflow on push to master or develop, except tag creation
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+    tags-ignore:
+      - '**'
+
+  # Trigger the workflow on pull request
+  pull_request: ~
+
+  # Trigger the workflow manually
+  workflow_dispatch: ~
+
+  # Trigger after public PR approved for CI
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  # Run CI including downstream packages on self-hosted runners
+  downstream-ci:
+    name: downstream-ci
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci.yml@main
+    with:
+      plume: ecmwf/plume@${{ github.event.pull_request.head.sha || github.sha }}
+      codecov_upload: true
+    secrets: inherit
+
+  # Run CI of private downstream packages on self-hosted runners
+  private-downstream-ci:
+    name: private-downstream-ci
+    needs: [downstream-ci]
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Dispatch private downstream CI
+        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        with:
+          token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          owner: ecmwf-actions
+          repository: private-downstream-ci
+          event_type: downstream-ci
+          payload: '{"plume": "ecmwf/plume@${{ github.event.pull_request.head.sha || github.sha }}"}'
+
+  # Build downstream packages on HPC
+  downstream-ci-hpc:
+    name: downstream-ci-hpc
+    if: ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    uses: ecmwf-actions/downstream-ci/.github/workflows/downstream-ci-hpc.yml@main
+    with:
+      plume: ecmwf/plume@${{ github.event.pull_request.head.sha || github.sha }}
+    secrets: inherit
+
+  # Run CI of private downstream packages on HPC
+  private-downstream-ci-hpc:
+    name: private-downstream-ci-hpc
+    needs: [downstream-ci-hpc]
+    if: (success() || failure()) && ${{ !github.event.pull_request.head.repo.fork && github.event.action != 'labeled' || github.event.label.name == 'approved-for-ci' }}
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Dispatch private downstream CI
+        uses: ecmwf-actions/dispatch-private-downstream-ci@v1
+        with:
+          token: ${{ secrets.GH_REPO_READ_TOKEN }}
+          owner: ecmwf-actions
+          repository: private-downstream-ci
+          event_type: downstream-ci-hpc
+          payload: '{"plume": "ecmwf/plume@${{ github.event.pull_request.head.sha || github.sha }}"}'

--- a/.github/workflows/label-public-pr.yml
+++ b/.github/workflows/label-public-pr.yml
@@ -1,0 +1,10 @@
+# Manage labels of pull requests that originate from forks
+name: label-public-pr
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    uses: ecmwf-actions/reusable-workflows/.github/workflows/label-pr.yml@v2


### PR DESCRIPTION
Enable downstream CI on self-hosted runners and HPC. CI on pull requests originating from forks can be approved by adding `approved-for-ci` label to the PR.