### PR TITLE
Add TSTEP and NFLEVG to emulator & fix zero-field generation

### DIFF
--- a/src/nwp_emulator/config_reader.cc
+++ b/src/nwp_emulator/config_reader.cc
@@ -115,6 +115,10 @@ bool ConfigReader::nextMessage(std::string& shortName, std::string& levtype, std
     }
     if (readerConfig_.has(fieldConfigStr + ".levels")) {
         std::string levelKey = getLevelConfigKey(level, fieldConfigStr + ".levels");
+        if (levelKey.empty()) { // this level should be filled with zeros
+            ++index_;
+            return true;
+        }
         fieldConfigStr += ".levels." + levelKey;
     }
     readerConfig_.get(fieldConfigStr, fieldConfig);
@@ -162,7 +166,7 @@ std::string ConfigReader::getLevelConfigKey(const std::string& level, const std:
             return key;
         }
     }
-    return "";  // should never happen if the config has been properly validated
+    return "";  // can be empty if the level should be only zeros
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/nwp_emulator/nwp_data_provider.cc
+++ b/src/nwp_emulator/nwp_data_provider.cc
@@ -49,20 +49,20 @@ NWPDataProvider::NWPDataProvider(const DataSourceType& sourceType, const eckit::
     }
 
     // Find the maximum number of levels across all params
-    size_t nlevels = 1;
+    nLevels_ = 1;
     for (const auto& levtypePair : params_) {
         size_t paramlevels = 0;
         for (const auto& levelPair : levtypePair.second) {
             paramlevels += levelPair.second.size();
         }
-        nlevels = std::max(nlevels, paramlevels);
+        nLevels_ = std::max(nLevels_, paramlevels);
     }
     std::map<std::string, int> fieldsMd;
     for (const auto& levtypePair : params_) {
         fieldsMd[levtypePair.first] = 1;  // 2D fields receive 1 level
         if (levtypePair.second.size() > 1 || levtypePair.second.begin()->second.size() > 1) {
             // All 3D fields receive the same number of levels even if some levels remain empty for some fields
-            fieldsMd[levtypePair.first] = nlevels;
+            fieldsMd[levtypePair.first] = nLevels_;
         }
     }
 
@@ -72,7 +72,7 @@ NWPDataProvider::NWPDataProvider(const DataSourceType& sourceType, const eckit::
     // Use the default partitioner for the given grid type
     atlas::grid::Distribution distribution(grid, atlas::util::Config("type", grid.partitioner().getString("type")) |
                                                      atlas::util::Config("bands", nprocs_));
-    fs_ = atlas::functionspace::StructuredColumns(grid, distribution, atlas::util::Config("levels", nlevels));
+    fs_ = atlas::functionspace::StructuredColumns(grid, distribution, atlas::util::Config("levels", nLevels_));
     if (sourceType_ == DataSourceType::CONFIG) {
         dataReader->setReaderArea(fs_.lonlat());
     }

--- a/src/nwp_emulator/nwp_data_provider.h
+++ b/src/nwp_emulator/nwp_data_provider.h
@@ -58,6 +58,7 @@ private:
     std::string gridName_;
     atlas::functionspace::StructuredColumns fs_;
     atlas::FieldSet modelFieldSet_;
+    size_t nLevels_;
 
     size_t rank_;
     size_t root_;
@@ -131,5 +132,6 @@ public:
     /// Getters
     atlas::FieldSet& getModelFieldSet() { return modelFieldSet_; }
     int getStep() const { return dataReader->getStep(); }
+    size_t getLevels() const { return nLevels_; }
 };
 }  // namespace nwp_emulator

--- a/src/nwp_emulator/nwp_emulator.cc
+++ b/src/nwp_emulator/nwp_emulator.cc
@@ -138,12 +138,16 @@ bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
 
     plume::Protocol offers;  /// Define data offered by Plume
     offers.offerInt("NSTEP", "always", "Simulation Step");
+    offers.offerDouble("TSTEP", "always", "Simulation Time Step");
+    offers.offerInt("NFLEVG", "always", "Number of vertical levels");
     auto fields = dataProvider.getModelFieldSet();
     for (const auto& field: fields) {
         offers.offerAtlasField(field.name(), "on-request", field.name());
     }
     plume::Manager::negotiate(offers);
     plumeData_.createInt("NSTEP", 0);  /// Initialise parameters
+    plumeData_.createDouble("TSTEP", 900.0);
+    plumeData_.createInt("NFLEVG", dataProvider.getLevels());
     for (auto& field: fields) {
         if (plume::Manager::isParamRequested(field.name())) {
             plumeData_.provideAtlasFieldShared(field.name(), field.get());
@@ -155,8 +159,8 @@ bool NWPEmulator::setupPlume(NWPDataProvider& dataProvider) {
 }
 
 void NWPEmulator::runPlume(int step) {
-    plumeData_.updateInt("NSTEP", step);
     plume::Manager::run();
+    plumeData_.updateInt("NSTEP", step);
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
Minor fix and added support for passing time step and vertical levels through Plume in the model data (used by the extreme events plugin).